### PR TITLE
[Fix/issue-template]: 이슈 템플릿 설정 및 경로 오류 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,5 +6,5 @@ blank_issues_enabled: false
 contact_links:
   - name: "🤔 질문 및 토론 (Questions & Discussion)"
     # 👇 이 URL을 실제 WePLi 프로젝트의 GitHub Discussions URL로 변경해주세요.
-    url: https://github.com/lee-jae-weon/WePLi-iOS/discussions
+    url: https://github.com/unib35/WePLi-iOS/discussions
     about: "프로젝트에 대한 간단한 질문이나 새로운 아이디어 제안, 자유로운 토론은 여기서 해주세요."

--- a/.github/ISSUE_TEMPLATE/todo.md
+++ b/.github/ISSUE_TEMPLATE/todo.md
@@ -1,9 +1,11 @@
+---
 name: "✅ To-Do (작업)"
 about: 새로운 작업을 등록합니다.
 title: "[Prefix] 이슈 제목"
 labels: "todo"
 assignees: ''
 
+---
 <!--
 
 Prefix


### PR DESCRIPTION
<!-- 
PR 제목은 다음과 같은 형식으로 작성해주세요.
- feat: 새로운 기능 추가
- fix: 버그 수정
- docs: 문서 수정
- style: 코드 포맷팅, 세미콜론 누락 등 (코드 로직 변경 없음)
- refactor: 코드 리팩토링
- test: 테스트 코드 추가/수정
- chore: 빌드 관련 파일 수정, 패키지 매니저 설정 등
-->

## 🔮 작업 요약

GitHub 이슈 템플릿의 설정 오류를 수정했습니다. '질문 및 토론' 링크의 경로를 현재 레포지토리에 맞게 업데이트하고, To-Do 템플릿의 포맷팅 오류를 바로잡았습니다.

## 🖥️ 상세 작업 내용

- [x] **Discussions 링크 경로 수정**: `.github/ISSUE_TEMPLATE/config.yml` 파일에서 '질문 및 토론' 링크의 URL을 현재 레포지토리(`unib35/WePLi-iOS`)로 업데이트했습니다.
- [x] **To-Do 템플릿 포맷팅 수정**: `.github/ISSUE_TEMPLATE/todo.md` 파일의 YAML front matter 구문 오류를 수정하여 템플릿이 정상적으로 인식되도록 했습니다.

## 📸 스크린샷

<!-- 변경 사항을 시각적으로 보여주는 스크린샷이나 GIF를 첨부해주세요. -->
<!-- UI 변경이 없다면 이 섹션은 생략해도 좋습니다. -->

설정 파일 수정으로 별도의 스크린샷은 없습니다.

## 📌 이슈 및 특이사항

- **이슈**: 이슈 생성 페이지에서 '질문 및 토론' 링크를 클릭하면 잘못된 레포지토리로 연결되는 문제가 있었습니다.
- **특이사항**: 레포지토리 소유권 이전 후 관련 링크 업데이트가 누락되어 발생한 문제였습니다. `todo.md` 템플릿의 포맷팅 오류도 함께 수정하여 이슈 생성 경험을 개선했습니다.

## 🚀 다음에 할 일

- 다른 GitHub 관련 설정 파일(예: `CONTRIBUTING.md`)에도 이전 레포지토리 경로가 남아있는지 확인하고, 필요시 추가 수정 진행.